### PR TITLE
fix error  when running "gradle eclipse" with gradle 2.0 :

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ uploadArchives {
 
 eclipse {
 	classpath {
-		plusConfigurations += configurations.provided
-		noExportConfigurations += configurations.provided
+		plusConfigurations += [configurations.provided]
+		noExportConfigurations += [configurations.provided]
 	}
 }


### PR DESCRIPTION
Execution failed for task ':eclipseClasspath'.

> java.io.File cannot be cast to org.gradle.api.artifacts.Configuration

fix from http://forums.gradle.org/gradle/topics/eclipse_plugin_broken_with_2_0_rc_1
