### PR TITLE
Provide support to display a SimpleApplication into a JavaFX's ImageView.

### DIFF
--- a/src/main/java/com/jme3x/jfx/injfx/JmeContextOffscreenSurface.java
+++ b/src/main/java/com/jme3x/jfx/injfx/JmeContextOffscreenSurface.java
@@ -1,0 +1,123 @@
+package com.jme3x.jfx.injfx;
+
+import com.jme3.input.JoyInput;
+import com.jme3.input.KeyInput;
+import com.jme3.input.MouseInput;
+import com.jme3.input.TouchInput;
+import com.jme3.renderer.Renderer;
+import com.jme3.system.AppSettings;
+import com.jme3.system.JmeContext;
+import com.jme3.system.JmeSystem;
+import com.jme3.system.SystemListener;
+import com.jme3.system.Timer;
+ 
+public class JmeContextOffscreenSurface implements JmeContext {
+	private final AppSettings settings = new AppSettings(true);
+	private JmeContext actualContext;
+
+	public JmeContextOffscreenSurface(){
+		this.settings.setRenderer(AppSettings.LWJGL_OPENGL2);
+	}
+
+	private JmeContext lazyActualContext() {
+		if (actualContext == null) {
+			actualContext = JmeSystem.newContext(this.settings, Type.OffscreenSurface);
+		}
+		return actualContext;
+	}
+
+	@Override
+	public Type getType() {
+		return Type.OffscreenSurface;
+	}
+
+	@Override
+	public void setSettings(AppSettings settings) {
+		this.settings.copyFrom(settings);
+		this.settings.setRenderer(AppSettings.LWJGL_OPENGL2);
+		lazyActualContext().setSettings(this.settings);
+	}
+
+	@Override
+	public void setSystemListener(SystemListener listener) {
+		lazyActualContext().setSystemListener(listener);
+	}
+
+	@Override
+	public AppSettings getSettings() {
+		return settings;
+	}
+
+	@Override
+	public Renderer getRenderer() {
+		return actualContext.getRenderer();
+	}
+
+	@Override
+	public MouseInput getMouseInput() {
+		//return actualContext.getMouseInput();
+		return null;
+	}
+
+	@Override
+	public KeyInput getKeyInput() {
+		//return actualContext.getKeyInput();
+		return null;
+	}
+
+	@Override
+	public JoyInput getJoyInput() {
+		return null;
+	}
+
+	@Override
+	public TouchInput getTouchInput() {
+		return null;
+	}
+
+	@Override
+	public Timer getTimer() {
+		return actualContext.getTimer();
+	}
+
+	@Override
+	public void setTitle(String title) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public boolean isCreated() {
+		return actualContext != null && actualContext.isCreated();
+	}
+
+	@Override
+	public boolean isRenderable() {
+		return actualContext != null && actualContext.isRenderable();
+	}
+
+	@Override
+	public void setAutoFlushFrames(boolean enabled) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void create(boolean waitFor) {
+		lazyActualContext().create(waitFor);
+	}
+
+	@Override
+	public void restart() {
+	}
+
+	@Override
+	public void destroy(boolean waitFor) {
+		if (actualContext == null)
+			throw new IllegalStateException("Not created");
+
+		// destroy wrapped context
+		actualContext.destroy(waitFor);
+	}
+
+}

--- a/src/main/java/com/jme3x/jfx/injfx/JmeForImageView.java
+++ b/src/main/java/com/jme3x/jfx/injfx/JmeForImageView.java
@@ -1,0 +1,113 @@
+package com.jme3x.jfx.injfx;
+
+import java.util.concurrent.Future;
+import java.util.function.Function;
+
+import javafx.scene.image.ImageView;
+
+import com.jme3.app.DebugKeysAppState;
+import com.jme3.app.SimpleApplication;
+import com.jme3.system.AppSettings;
+
+/**
+ * JmeForImageView create a jme'SimpleApplication viewable into an JavaFX's ImageView.
+ *
+ * You can manage the wrapped SimpleApplication by calling enqueue (by example to add/remove
+ * AppState, Node, Light, to change the AppSettings...).
+ *
+ * See TestDisplayInImageView.java for sample usage.
+ *
+ * The usage of the class is optional, it can avoid some
+ * pitfall in the configuration. If you want a better control, I suggest you to browse
+ * the source of this class to see sample of configuration and usage of
+ * SceneProcessorCopyToImage.
+ *
+ * @TODO auto-stop when the ImageView is removed from JavaFX Stage
+ * @author davidB
+ */
+public class JmeForImageView {
+
+	private static SimpleApplication makeJmeApplication(int framerate) {
+		AppSettings settings = new AppSettings(true);
+
+		// important to use those settings
+		settings.setFullscreen(false);
+		settings.setUseInput(false);
+		settings.setFrameRate(Math.max(1, Math.min(60, framerate)));
+		settings.setCustomRenderer(com.jme3x.jfx.injfx.JmeContextOffscreenSurface.class);
+
+		SimpleApplication app = new SimpleApplication(){
+			@Override
+			public void simpleInitApp() {
+				// to prevent a NPE (due to setUseInput(null)) on Application.stop()
+				getStateManager().detach(getStateManager().getState(DebugKeysAppState.class));
+			}
+		};
+		app.setSettings(settings);
+		app.setShowSettings(false);
+		return app;
+	}
+
+	private SimpleApplication jmeApp0;
+	private SceneProcessorCopyToImageView jmeAppDisplayBinder = new SceneProcessorCopyToImageView();
+
+	/**
+	 * Lazy creation of the wrapped SimpleApplication.
+	 */
+	private SimpleApplication findOrCreate() {
+		if (jmeApp0 == null) {
+			jmeApp0 = makeJmeApplication(30);
+			jmeApp0.start();
+		}
+		return jmeApp0;
+	}
+
+	/**
+	 * Bind the wrapped SimpleApplication to an imageView.
+	 *
+	 * <ul>
+	 * <li>Only one imageView can be binded.</li>
+	 * <li>Only jmeApp.getViewPort(), jmeApp.getGuiViewPort() are binded</li>
+	 * </ul>
+	 *
+	 * @param imageView destination
+	 * @return Future when bind is done (async)
+	 */
+	public Future<Boolean> bind(ImageView imageView) {
+		return enqueue((jmeApp) -> {
+			jmeAppDisplayBinder.bind(imageView, true, jmeApp.getViewPort(), jmeApp.getGuiViewPort());
+			return true;
+		});
+	}
+
+	public Future<Boolean> unbind() {
+		return enqueue((jmeApp) -> {
+			jmeAppDisplayBinder.bind(null, true);
+			return true;
+		});
+	}
+
+	/**
+	 * Enqueue action to apply in Jme's Thread
+	 * Action can be add/remove AppState, Node, Light,
+	 * change the AppSettings....
+	 *
+	 * @param f(jmeApp) the action to apply
+	 */
+	public <R> Future<R> enqueue(Function<SimpleApplication,R> f) {
+		SimpleApplication jmeApp = findOrCreate();
+		return jmeApp.enqueue(() -> {return f.apply(jmeApp);});
+	}
+
+	public void stop(boolean waitFor) {
+		if (jmeApp0 != null){
+			try {
+				unbind().get();
+			} catch (Exception exc) {
+				//TODO
+				exc.printStackTrace();
+			}
+			jmeApp0.stop(waitFor);
+		}
+	}
+}

--- a/src/main/java/com/jme3x/jfx/injfx/SceneProcessorCopyToImageView.java
+++ b/src/main/java/com/jme3x/jfx/injfx/SceneProcessorCopyToImageView.java
@@ -1,0 +1,179 @@
+package com.jme3x.jfx.injfx;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javafx.beans.value.ChangeListener;
+import javafx.scene.image.ImageView;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.WritableImage;
+
+import com.jme3.post.SceneProcessor;
+import com.jme3.renderer.RenderManager;
+import com.jme3.renderer.ViewPort;
+import com.jme3.renderer.queue.RenderQueue;
+import com.jme3.texture.FrameBuffer;
+import com.jme3.texture.Image.Format;
+import com.jme3.util.BufferUtils;
+import com.jme3x.jfx.FxPlatformExecutor;
+
+//https://github.com/caprica/vlcj-javafx/blob/master/src/test/java/uk/co/caprica/vlcj/javafx/test/JavaFXDirectRenderingTest.java
+//http://stackoverflow.com/questions/15951284/javafx-image-resizing
+//TODO manage suspend/resume (eg when image/stage is hidden)
+//FIXME better management of sync data  buffer + size (immutable ?) between async read / async write (to avoid IndexOutOfBoundsException reproduce the bug increase framerate and resize)
+public class SceneProcessorCopyToImageView implements SceneProcessor {
+
+	private FrameBuffer fb;
+	private ByteBuffer byteBuf;
+	private RenderManager rm;
+	boolean attachAsMain = true;
+	private ArrayList<ViewPort> viewPorts = new ArrayList<ViewPort>();
+	private int askWidth  = 1;
+	private int askHeight = 1;
+	private int width  = 1;
+	private int height = 1;
+	private AtomicBoolean reshapeNeeded  = new AtomicBoolean(true);
+
+	private WritableImage img;
+	private final Object imgLock = new Object();
+	private ImageView imgView;
+	private ChangeListener<? super Number> wlistener = (w,o,n)->{
+		componentResized(n.intValue(), (int)this.imgView.getFitHeight());
+	};
+	private ChangeListener<? super Number> hlistener = (w,o,n)->{
+		componentResized((int)this.imgView.getFitWidth(), n.intValue());
+	};
+
+	public void componentResized(int w, int h) {
+		int newWidth2 = Math.max(w, 1);
+		int newHeight2 = Math.max(h, 1);
+		if (width != newWidth2 || height != newHeight2){
+			askWidth = newWidth2;
+			askHeight = newHeight2;
+			reshapeNeeded.set(true);
+		}
+	}
+
+	public void bind(ImageView view, boolean overrideMainFramebuffer, ViewPort ... vps){
+		if (viewPorts.size() > 0){
+			for (ViewPort vp : viewPorts){
+				vp.setOutputFrameBuffer(null);
+			}
+			viewPorts.get(viewPorts.size()-1).removeProcessor(this);
+		}
+
+		viewPorts.addAll(Arrays.asList(vps));
+		viewPorts.get(viewPorts.size()-1).addProcessor(this);
+		attachAsMain = overrideMainFramebuffer;
+
+		if (imgView != null) {
+			imgView.fitWidthProperty().removeListener(wlistener);
+			imgView.fitHeightProperty().removeListener(hlistener);
+		}
+		imgView = view;
+		if (imgView != null) {
+			imgView.fitWidthProperty().addListener(wlistener);
+			imgView.fitHeightProperty().addListener(hlistener);
+			componentResized((int)imgView.getFitWidth(), (int)imgView.getFitHeight());
+		}
+	}
+
+	@Override
+	public void initialize(RenderManager rm, ViewPort vp) {
+		if (this.rm == null){
+			// First time called in OGL thread
+			this.rm = rm;
+			reshapeInThread(1, 1);
+		}
+	}
+	public void repaintInThread(){
+		// Convert screenshot.
+		byteBuf.clear();
+		rm.getRenderer().readFrameBuffer(fb, byteBuf);
+		FxPlatformExecutor.runOnFxApplication(() -> {
+			synchronized (imgLock){
+				img.getPixelWriter().setPixels(0, 0, width, height, PixelFormat.getByteBgraInstance(), byteBuf, width * 4);
+			}
+		});
+	}
+
+	private void reshapeInThread(int width0, int height0) {
+		width = width0;
+		height = height0;
+		byteBuf = BufferUtils.ensureLargeEnough(byteBuf, width * height * 4);
+
+		fb = new FrameBuffer(width, height, 1);
+		fb.setDepthBuffer(Format.Depth);
+		fb.setColorBuffer(Format.RGB8);
+
+		if (attachAsMain){
+			rm.getRenderer().setMainFrameBufferOverride(fb);
+		}
+
+		synchronized (imgLock){
+			img = new WritableImage(width, height);//, BufferedImage.TYPE_INT_RGB);
+		}
+		FxPlatformExecutor.runOnFxApplication(() -> {
+			//this.canvas.setScaleX(-1.0);
+			this.imgView.setScaleY(-1.0);
+			synchronized (imgLock){
+				imgView.setImage(img);
+			}
+		});
+
+		for (ViewPort vp : viewPorts){
+			if (!attachAsMain){
+				vp.setOutputFrameBuffer(fb);
+			}
+			vp.getCamera().resize(width, height, true);
+
+			// NOTE: Hack alert. This is done ONLY for custom framebuffers.
+			// Main framebuffer should use RenderManager.notifyReshape().
+			for (SceneProcessor sp : vp.getProcessors()){
+				sp.reshape(vp, width, height);
+			}
+			rm.notifyReshape(width, height);
+		}
+	}
+
+	@Override
+	public boolean isInitialized() {
+		return fb != null;
+	}
+
+	@Override
+	public void preFrame(float tpf) {
+	}
+
+	@Override
+	public void postQueue(RenderQueue rq) {
+	}
+
+	@Override
+	public void postFrame(FrameBuffer out) {
+		if (!attachAsMain && out != fb){
+			throw new IllegalStateException("Why did you change the output framebuffer?");
+		}
+		if (imgView == null) {
+			return;
+		}
+
+		if (reshapeNeeded.getAndSet(false)){
+			reshapeInThread(askWidth, askHeight);
+		}else if (imgView.isVisible()) {
+			//System.out.print(".");
+			repaintInThread();
+		}
+	}
+
+	@Override
+	public void cleanup() {
+	}
+
+	@Override
+	public void reshape(ViewPort vp, int w, int h) {
+	}
+
+}

--- a/src/test/java/com/jme3x/jfx/TestDisplayInImageView.fxml
+++ b/src/test/java/com/jme3x/jfx/TestDisplayInImageView.fxml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.*?>
+<?import javafx.scene.effect.*?>
+<?import javafx.scene.*?>
+<?import javafx.embed.swing.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.canvas.*?>
+<?import javafx.scene.text.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.paint.*?>
+<?import javafx.scene.shape.*?>
+<?import java.lang.*?>
+<?import javafx.scene.layout.*?>
+
+
+<BorderPane prefHeight="400.0" prefWidth="477.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.jme3x.jfx.TestDisplayInImageView$Controller">
+   <bottom>
+      <GridPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="96.0" prefWidth="223.0" BorderPane.alignment="CENTER">
+        <columnConstraints>
+          <ColumnConstraints hgrow="NEVER" />
+          <ColumnConstraints hgrow="ALWAYS" maxWidth="1.7976931348623157E308" />
+        </columnConstraints>
+        <rowConstraints>
+            <RowConstraints fillHeight="false" maxHeight="116.0" minHeight="10.0" prefHeight="38.0" vgrow="NEVER" />
+            <RowConstraints fillHeight="false" maxHeight="116.0" minHeight="10.0" prefHeight="38.0" vgrow="NEVER" />
+            <RowConstraints fillHeight="false" maxHeight="116.0" minHeight="10.0" prefHeight="38.0" vgrow="NEVER" />
+        </rowConstraints>
+         <children>
+            <ColorPicker fx:id="bgColor" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" />
+            <Label text="Background" />
+            <Label text="Show Stats" GridPane.rowIndex="1" />
+            <CheckBox fx:id="showStats" mnemonicParsing="false" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+            <Slider fx:id="fpsReq" max="240.0" min="1.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+            <Label fx:id="fpsLabel" text="Label" GridPane.rowIndex="2" />
+         </children>
+      </GridPane>
+   </bottom>
+   <center>
+      <VBox minHeight="0.0" minWidth="0.0" prefHeight="200.0" prefWidth="100.0" BorderPane.alignment="CENTER">
+         <children>
+            <ImageView fx:id="image" fitHeight="308.0" fitWidth="477.0" pickOnBounds="true" smooth="false" />
+         </children>
+      </VBox>
+   </center>
+</BorderPane>

--- a/src/test/java/com/jme3x/jfx/TestDisplayInImageView.java
+++ b/src/test/java/com/jme3x/jfx/TestDisplayInImageView.java
@@ -1,0 +1,192 @@
+package com.jme3x.jfx;
+
+import java.net.URL;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.event.EventHandler;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.fxml.JavaFXBuilderFactory;
+import javafx.scene.Scene;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ColorPicker;
+import javafx.scene.control.Label;
+import javafx.scene.control.Slider;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.asset.AssetManager;
+import com.jme3.light.DirectionalLight;
+import com.jme3.material.Material;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Vector3f;
+import com.jme3.renderer.queue.RenderQueue.Bucket;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Node;
+import com.jme3.scene.shape.Box;
+import com.jme3.scene.shape.Sphere;
+import com.jme3.system.AppSettings;
+import com.jme3.util.TangentBinormalGenerator;
+import com.jme3x.jfx.injfx.JmeForImageView;
+
+public class TestDisplayInImageView extends Application {
+
+	public static void main(String[] args) {
+		launch(args);
+	}
+
+	@Override
+	public void start(Stage stage) throws Exception {
+		final FXMLLoader fxmlLoader = new FXMLLoader();
+		final URL location = Thread.currentThread().getContextClassLoader().getResource(this.getClass().getCanonicalName().replace('.', '/')+".fxml");
+		fxmlLoader.setLocation(location);
+		//final ResourceBundle defaultRessources = fxmlLoader.getResources();
+		//fxmlLoader.setResources(this.addCustomRessources(defaultRessources));
+		fxmlLoader.setBuilderFactory(new JavaFXBuilderFactory());
+		final Region root = fxmlLoader.load(location.openStream());
+		Controller controller = fxmlLoader.getController();
+
+		JmeForImageView jme = new JmeForImageView();
+		jme.bind(controller.image);
+
+		stage.setOnCloseRequest(new EventHandler<WindowEvent>() {
+		      public void handle(WindowEvent e){
+				jme.stop(true);
+		      }
+		});
+
+		bindOtherControls(jme, controller);
+		jme.enqueue(TestDisplayInImageView::createScene);
+
+		Scene scene = new Scene(root, 600, 400);
+		stage.setTitle(this.getClass().getSimpleName());
+		stage.setScene(scene);
+		stage.show();
+	}
+
+	@Override
+	public void stop() throws Exception {
+		Platform.exit();
+	}
+
+	static void bindOtherControls(JmeForImageView jme, Controller controller) {
+		controller.bgColor.valueProperty().addListener((ov, o, n) -> {
+			jme.enqueue((jmeApp) -> {
+				jmeApp.getViewPort().setBackgroundColor(new ColorRGBA((float)n.getRed(), (float)n.getGreen(), (float)n.getBlue(), (float)n.getOpacity()));
+				return null;
+			});
+		});
+		controller.bgColor.setValue(Color.LIGHTGRAY);
+
+		controller.showStats.selectedProperty().addListener((ov, o, n) -> {
+			jme.enqueue((jmeApp) -> {
+				jmeApp.setDisplayStatView(n);
+				jmeApp.setDisplayFps(n);
+				return null;
+			});
+		});
+		controller.showStats.setSelected(!controller.showStats.isSelected());
+
+		controller.fpsReq.valueProperty().addListener((ov, o, n) -> {
+			jme.enqueue((jmeApp) -> {
+				AppSettings settings = new AppSettings(false);
+				settings.setFullscreen(false);
+				settings.setUseInput(false);
+				settings.setFrameRate(n.intValue());
+				settings.setCustomRenderer(com.jme3x.jfx.injfx.JmeContextOffscreenSurface.class);
+				jmeApp.setSettings(settings);
+				jmeApp.restart();
+				return null;
+			});
+		});
+		controller.fpsReq.setValue(30);
+	}
+
+	/**
+	 * Create a similar scene to Tutorial "Hello Material" but without texture
+	 * http://hub.jmonkeyengine.org/wiki/doku.php/jme3:beginner:hello_material
+	 *
+	 * @param jmeApp the application where to create a Scene
+	 */
+	static boolean createScene(SimpleApplication jmeApp) {
+		Node rootNode = jmeApp.getRootNode();
+		AssetManager assetManager = jmeApp.getAssetManager();
+
+		/** A simple textured cube -- in good MIP map quality. */
+		Box cube1Mesh = new Box( 1f,1f,1f);
+		Geometry cube1Geo = new Geometry("My Textured Box", cube1Mesh);
+		cube1Geo.setLocalTranslation(new Vector3f(-3f,1.1f,0f));
+		Material cube1Mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+		cube1Mat.setColor("Color", ColorRGBA.Blue);
+		cube1Geo.setMaterial(cube1Mat);
+		rootNode.attachChild(cube1Geo);
+
+		/** A translucent/transparent texture, similar to a window frame. */
+		Box cube2Mesh = new Box( 1f,1f,0.01f);
+		Geometry cube2Geo = new Geometry("window frame", cube2Mesh);
+		Material cube2Mat = new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md");
+		cube2Mat.setColor("Color", ColorRGBA.Brown);
+		cube2Geo.setQueueBucket(Bucket.Transparent);
+		cube2Geo.setMaterial(cube2Mat);
+		rootNode.attachChild(cube2Geo);
+
+		/** A bumpy rock with a shiny light effect.*/
+		Sphere sphereMesh = new Sphere(32,32, 2f);
+		Geometry sphereGeo = new Geometry("Shiny rock", sphereMesh);
+		sphereMesh.setTextureMode(Sphere.TextureMode.Projected); // better quality on spheres
+		TangentBinormalGenerator.generate(sphereMesh);           // for lighting effect
+		Material sphereMat = new Material(assetManager, "Common/MatDefs/Light/Lighting.j3md");
+		sphereMat.setBoolean("UseMaterialColors",true);
+		sphereMat.setColor("Diffuse",ColorRGBA.Pink);
+		sphereMat.setColor("Specular",ColorRGBA.White);
+		sphereMat.setFloat("Shininess", 64f);  // [0,128]
+		sphereGeo.setMaterial(sphereMat);
+		sphereGeo.setLocalTranslation(0,2,-2); // Move it a bit
+		sphereGeo.rotate(1.6f, 0, 0);          // Rotate it a bit
+		rootNode.attachChild(sphereGeo);
+
+		/** Must add a light to make the lit object visible! */
+		DirectionalLight sun = new DirectionalLight();
+		sun.setDirection(new Vector3f(1,0,-2).normalizeLocal());
+		sun.setColor(ColorRGBA.White);
+		rootNode.addLight(sun);
+		return true;
+	}
+
+	public static class Controller {
+
+		@FXML
+		public ImageView image;
+
+		@FXML
+		public ColorPicker bgColor;
+
+		@FXML
+		public CheckBox showStats;
+
+		@FXML
+		private Label fpsLabel;
+
+		@FXML
+		public Slider fpsReq;
+
+		@FXML
+		public void initialize() {
+			//To resize image when parent is resize
+			//image is wrapped into a "VBOX" or "HBOX" to allow resize smaller
+			//see http://stackoverflow.com/questions/15951284/javafx-image-resizing
+			Pane p = (Pane)image.getParent();
+			image.fitHeightProperty().bind(p.heightProperty());
+			image.fitWidthProperty().bind(p.widthProperty());
+
+			fpsReq.valueProperty().addListener((ov, o, n) -> fpsLabel.setText(String.format("fps : %4d", n.intValue())));
+		}
+
+	}
+}


### PR DESCRIPTION
 The core is SceneProcessorCopyToImageView + JmeContextOffscreenSurface
JmeForImageView is a helper class use to hide common boilerplate (I create it after my 3rd setup).
TestDisplayInImageView is a sample where user can change background color, change framerate (1-200), show/hide stats.

There some TODO and FIXME, but the current code is usable, try the TestDisplayInImageView (only crash during resize with 30+ framerate, The main FIXME).

The code is based on SDK SceneViewer and usage of AwtJmeContext.
