### PR TITLE
Plugin 'sonar-runner' has been removed and now it's called 'org.sonarqube'. Removed 'noExportConfigurations' for eclipse.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
-apply plugin: "sonar-runner"
+apply plugin: 'org.sonarqube'
 
 
 /////////////////git version logic///////////////
@@ -77,9 +77,14 @@ artifacts {
 eclipse {
 	classpath {
 		plusConfigurations += [configurations.provided]
-		noExportConfigurations += [configurations.provided]
+		
+		// * What went wrong:
+		// A problem occurred evaluating root project 'jfx'.
+		// > Could not get unknown property 'noExportConfigurations' for object of type org.gradle.plugins.ide.eclipse.model.EclipseClasspath.
+		// noExportConfigurations += [configurations.provided]	
 	}
 }
+
 idea {
 	module {
 		scopes.PROVIDED.plus += [configurations.provided]
@@ -87,16 +92,22 @@ idea {
 }
 
 buildscript {
-	repositories { jcenter() }
-	dependencies { classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.5' }
+	repositories {
+		jcenter()
+		maven { url "https://plugins.gradle.org/m2/" }
+	}
+	dependencies { 
+		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.5'	
+		classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.0.1'
+	}
 }
 
 jar {
 	manifest { attributes("Implementation-Version": buildVersion) }
 }
 
-sonarRunner {
-	sonarProperties {
+sonarqube {
+	properties {
 		property "sonar.host.url", sonarUrl
 		property "sonar.jdbc.url", sonarDBUrl
 		property "sonar.jdbc.driverClassName", sonarDBDriver


### PR DESCRIPTION
It's working again:

![Screen](https://panda-lang.org/screenshot/I3CXkUEv.png)